### PR TITLE
Update POST request for all stamps to be GET request

### DIFF
--- a/gorapass-frontend/src/components/AllStamps.jsx
+++ b/gorapass-frontend/src/components/AllStamps.jsx
@@ -1,25 +1,17 @@
 
 import {Link} from "react-router-dom"
 import { useState, useEffect } from 'react'
-import Cookies from 'js-cookie'
-
 
 const AllStamps = () => {
 
   const [stamps, setStamps] = useState([])
 
-  const csrftoken = Cookies.get('csrftoken')
-
   useEffect(() => {
-    fetch("http://localhost:8000/gorapass/stamps", {
-      credentials:'include',
-      method:'POST',
-      headers: {'X-CSRFToken':csrftoken}
-    })
+    fetch("http://localhost:8000/gorapass/stamps")
       .then(response => response.json())
       .then(json => setStamps(json))
       .catch(error => console.error(error));
-  }, [csrftoken]);
+  }, []);
 
   return (
     <div>
@@ -30,7 +22,6 @@ const AllStamps = () => {
             <Link to={`/stamps/${stamp.id}`}>{stamp.stamp_name}</Link>
           </li>
         )}
-
       </ul>
     </div>
   )


### PR DESCRIPTION
We probably shouldn't use POST requests if we want to just retrieve all the stamps or if we aren't passing in any data in the request body. The AllStamps component was using a POST request to retrieve data on all the stamps, this should probably be a GET request. 

If we move to a model where there are collections, and collections contain stamps, then maybe we'll need to go back to a POST request and filter for collections. 