### PR TITLE
Redirect when not logged in, render stamps

### DIFF
--- a/gorapass-frontend/src/App.jsx
+++ b/gorapass-frontend/src/App.jsx
@@ -5,16 +5,14 @@ import {
 } from 'react-router-dom'
 import { useState } from 'react'
 
-
-import Home from './components/Home'
 import AllStamps from './components/AllStamps'
-import OpenStamps from './components/OpenStamps'
-import CompletedStamps from './components/CompletedStamps'
-import Stamp from './components/Stamp'
-import RegisterAndLogin from './components/RegisterAndLogin'
 import CompletedHikes from './components/CompletedHikes'
-
-
+import CompletedStamps from './components/CompletedStamps'
+import Home from './components/Home'
+import Login from './components/Login'
+import OpenStamps from './components/OpenStamps'
+import RegisterAndLogin from './components/RegisterAndLogin'
+import Stamp from './components/Stamp'
 
 const App = () => {
 
@@ -50,7 +48,7 @@ const App = () => {
         <Route path="/stamps/:id" element={<Stamp />} />
         <Route path="/register" element = {<RegisterAndLogin />} />
         <Route path="/completed_hikes" element = {<CompletedHikes />} />
-        {/* <Route path="/login" element = {<Login />} /> */}
+        <Route path="/login" element = {<Login />} />
       </Routes>
 
       <div>

--- a/gorapass-frontend/src/components/CompletedHikes.jsx
+++ b/gorapass-frontend/src/components/CompletedHikes.jsx
@@ -8,7 +8,7 @@ const CompletedHikes = () => {
   useEffect(() => {
     const fetchCompletedHikes = async () => {
       try {
-        const response = await fetch("http://localhost:8000/gorapass/users/2/completed_hikes", {
+        const response = await fetch("http://localhost:8000/gorapass/users/completed_hikes", {
           credentials: 'include',
         });
 

--- a/gorapass-frontend/src/components/CompletedHikes.jsx
+++ b/gorapass-frontend/src/components/CompletedHikes.jsx
@@ -1,26 +1,44 @@
-import { useState, useEffect } from 'react'
-
-
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const CompletedHikes = () => {
+  const navigate = useNavigate();
   const [completedHikes, setCompletedHikes] = useState([])
 
-
-
   useEffect(() => {
-    fetch("http://localhost:8000/gorapass/users/2/completed_hikes")
-      .then(response => response.json())
-      .then(json => setCompletedHikes(json))
-      .catch(error => console.error(error));
-  }, []);
+    const fetchCompletedHikes = async () => {
+      try {
+        const response = await fetch("http://localhost:8000/gorapass/users/2/completed_hikes", {
+          credentials: 'include',
+        });
 
+        if (response.status === 401) {
+          navigate('/login');
+          return;
+        }
 
+        if (response.status === 200) {
+          const json = await response.json();
+          setCompletedHikes(json);
+        }
+
+        else {
+          throw new Error(`Unaccounted for response: ${response.status}`);
+        }
+
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchCompletedHikes();
+  }, [navigate]);
 
   return (
     <div>
       <h1>All Completed Hikes</h1>
       <ul>
-         {completedHikes.map(hike =>
+          {completedHikes.map(hike =>
           <li key={hike.id}>
             {hike.hike_name}
           </li>
@@ -29,7 +47,5 @@ const CompletedHikes = () => {
     </div>
   )
 }
-
-
 
 export default CompletedHikes

--- a/gorapass-frontend/src/components/CompletedStamps.jsx
+++ b/gorapass-frontend/src/components/CompletedStamps.jsx
@@ -8,7 +8,7 @@ const CompletedStamps = () => {
   useEffect(() => {
     const fetchCompletedStamps = async () => {
       try {
-        const response = await fetch("http://localhost:8000/gorapass/users/2/completed_stamps", {
+        const response = await fetch("http://localhost:8000/gorapass/users/completed_stamps", {
           credentials: 'include',
         });
 

--- a/gorapass-frontend/src/components/CompletedStamps.jsx
+++ b/gorapass-frontend/src/components/CompletedStamps.jsx
@@ -1,12 +1,51 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const CompletedStamps = () => {
+  const navigate = useNavigate();
+  const [completedStamps, setCompletedStamps] = useState([])
+
+  useEffect(() => {
+    const fetchCompletedStamps = async () => {
+      try {
+        const response = await fetch("http://localhost:8000/gorapass/users/2/completed_stamps", {
+          credentials: 'include',
+        });
+
+        if (response.status === 401) {
+          navigate('/login');
+          return;
+        }
+
+        if (response.status === 200) {
+          const json = await response.json();
+          setCompletedStamps(json);
+        }
+
+        else {
+          throw new Error(`Unaccounted for response: ${response.status}`);
+        }
+
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchCompletedStamps();
+  }, [navigate]);
+
   return (
     <div>
       <h1>All Completed Stamps</h1>
+      <ul>
+          {completedStamps.map(stamp =>
+          <li key={stamp.id}>
+            {stamp.stamp_name}
+          </li>
+        )}
+      </ul>
     </div>
   )
 }
-
-
 
 export default CompletedStamps


### PR DESCRIPTION
This PR does a few things relevant to the "Completed Hikes" and "Completed Stamps" page.

1. Utilize `async/await` over fetch.
2. Catch `401` responses (not authorized) and redirect to the `/login` route.
3. Remove the hard-coded user id from the routes that were fetching this data. This coincides with a change on the backend. Both PRs will need to be made for this to work....now that I think of it, I probably should've left the old endpoints to make it compatible until this was migrated, and then remove the endpoints once this was merged. Ah, well. Live and learn, yeah?